### PR TITLE
Travis: Reenable stable, and test weave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-sudo: false
-
 language: rust
 
+before_install:
+  - sudo apt-get install -y cssc
+
 rust:
-  # For now, disable stable, until Rust 2018 becomes stable.
-  #    - stable
+    - stable
     - beta
     - nightly
 
@@ -13,5 +13,8 @@ matrix:
         - rust: nightly
 
 script:
+    - cargo build
+    - cargo test
+    - cd weave
     - cargo build
     - cargo test


### PR DESCRIPTION
The weave test makes use of 'cssc', so add this package.